### PR TITLE
AndroidManifest: expose .SnapclientService, fixes #34

### DIFF
--- a/Snapcast/src/main/AndroidManifest.xml
+++ b/Snapcast/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
             </intent-filter>
         </receiver>
 
-        <service android:name=".SnapclientService" />
+        <service android:name=".SnapclientService" android:exported="true" />
 
         <!-- android:theme="@style/Theme.AppCompat.Light.DialogWhenLarge" -->
         <activity


### PR DESCRIPTION
Hi!

This change allows users to directly start/stop the snapclient service via shell:

Start:
`shell am startservice -n de.badaix.snapcast/.SnapclientService --es "EXTRA_HOST" "host_address_here" --ei "EXTRA_PORT" 1704 -a "ACTION_START"`

Stop:
`shell am startservice -n de.badaix.snapcast/.SnapclientService -a "ACTION_STOP"`

This in turn allows Tasker users to set up actions that can start/stop the player, as requested in #34 