### PR TITLE
Switch to new android-release-signer action

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -30,7 +30,7 @@ jobs:
     - name: rename apk
       run: mv /home/runner/work/snapdroid/snapdroid/Snapcast/build/outputs/apk/release/Snapcast-release-unsigned.apk /home/runner/work/snapdroid/snapdroid/Snapcast/build/outputs/apk/release/Snapcast.apk 
 
-    - uses: r0adkll/sign-android-release@v1
+    - uses: filippoLeporati93/android-release-signer@v1
       if: github.event_name == 'push'
       name: Sign app APK
       # ID used to access action output


### PR DESCRIPTION
You are using the action `r0adkll/sign-android-release@v1` in your workflow file. This action causes some warnings due to outdated dependencies and deprecated commands. See the warnings here:
https://github.com/badaix/snapdroid/actions/runs/8803464482

There is some likelihood that the action will stop working at some point if the issues are not going to be fixed.

The corresponding repo seems unmaintained:
https://github.com/r0adkll/sign-android-release/issues/80
https://github.com/r0adkll/sign-android-release/issues/83

One user created a fork and fixed the issues
https://github.com/filippoLeporati93/android-release-signer