### PR TITLE
Add option to make screen off optional

### DIFF
--- a/Snapcast/src/main/java/de/badaix/snapcast/MainActivity.java
+++ b/Snapcast/src/main/java/de/badaix/snapcast/MainActivity.java
@@ -231,6 +231,15 @@ public class MainActivity extends AppCompatActivity implements GroupItem.GroupIt
             Settings.getInstance(this).put("hide_offline", item.isChecked());
             groupListFragment.setHideOffline(item.isChecked());
             return true;
+        } else if (id == R.id.action_prevent_screen_off) {
+            item.setChecked(!item.isChecked());
+            Settings.getInstance(this).put("prevent_screen_off", item.isChecked());
+            // Update the wake lock setting in the SnapclientService
+            if (snapclientService != null) {
+                boolean fullWakeLock = item.isChecked();  // true = FULL_WAKE_LOCK, false = PARTIAL_WAKE_LOCK
+                snapclientService.updateWakeLock(fullWakeLock);
+            }
+            return true; 
         } else if (id == R.id.action_refresh) {
             if (host.trim().isEmpty()) {
                 showWarning(getString(R.string.host_empty));
@@ -242,7 +251,6 @@ public class MainActivity extends AppCompatActivity implements GroupItem.GroupIt
             Intent intent = new Intent(this, AboutActivity.class);
             startActivity(intent);
         }
-
         return super.onOptionsItemSelected(item);
     }
 

--- a/Snapcast/src/main/java/de/badaix/snapcast/SnapclientService.java
+++ b/Snapcast/src/main/java/de/badaix/snapcast/SnapclientService.java
@@ -280,15 +280,17 @@ public class SnapclientService extends Service {
             android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_URGENT_AUDIO);
 
             PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
+            boolean preventScreenOff = Settings.getInstance(getApplicationContext()).getBoolean("prevent_screen_off", false);
 
-            UiModeManager uiModeManager = (UiModeManager) getSystemService(UI_MODE_SERVICE);
-            if (uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION) {
-                Log.d(TAG, "Running on a TV Device");
+            // Set the wake lock type based on the setting
+            if (preventScreenOff) {
+                Log.d(TAG, "Using FULL_WAKE_LOCK due to setting");
                 wakeLock = powerManager.newWakeLock(FULL_WAKE_LOCK, "snapcast:SnapcastFullWakeLock");
             } else {
-                Log.d(TAG, "Running on a non-TV Device");
+                Log.d(TAG, "Using PARTIAL_WAKE_LOCK due to setting");
                 wakeLock = powerManager.newWakeLock(PARTIAL_WAKE_LOCK, "snapcast:SnapcastPartialWakeLock");
             }
+            wakeLock = powerManager.newWakeLock(PARTIAL_WAKE_LOCK, "snapcast:SnapcastPartialWakeLock");
 
             wakeLock.acquire();
 
@@ -379,6 +381,27 @@ public class SnapclientService extends Service {
         }
         if (listener != null)
             listener.onPlayerStop(this);
+    }
+
+    public void updateWakeLock(boolean useFullWakeLock) {
+        try {
+            if (wakeLock != null && wakeLock.isHeld()) {
+                wakeLock.release();
+            }
+
+            PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
+            if (useFullWakeLock) {
+                Log.d(TAG, "Switching to FULL_WAKE_LOCK");
+                wakeLock = powerManager.newWakeLock(PowerManager.FULL_WAKE_LOCK, "snapcast:SnapcastFullWakeLock");
+            } else {
+                Log.d(TAG, "Switching to PARTIAL_WAKE_LOCK");
+                wakeLock = powerManager.newWakeLock(PARTIAL_WAKE_LOCK, "snapcast:SnapcastPartialWakeLock");
+            }
+
+            wakeLock.acquire();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public interface SnapclientListener {

--- a/Snapcast/src/main/res/menu/menu_snapcast.xml
+++ b/Snapcast/src/main/res/menu/menu_snapcast.xml
@@ -37,4 +37,10 @@
         android:orderInCategory="100"
         android:title="@string/action_hide_offline"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/action_prevent_screen_off"
+        android:checkable="true"
+        android:orderInCategory="100"
+        android:title="@string/action_prevent_screen_off"
+        app:showAsAction="never" />
 </menu>

--- a/Snapcast/src/main/res/values-de/strings.xml
+++ b/Snapcast/src/main/res/values-de/strings.xml
@@ -16,6 +16,7 @@
     <string name="action_scan">Suche nach Server</string>
     <string name="action_refresh">Aktualisiere Client-Liste</string>
     <string name="action_hide_offline">Verstecke offline Clients</string>
+    <string name="action_prevent_screen_off">Bildschirm ausschalten verhindern</string>
 
     <string name="title_activity_client_settings">Client Einstellungen</string>
     <string name="client_name">Name</string>

--- a/Snapcast/src/main/res/values-ja/strings.xml
+++ b/Snapcast/src/main/res/values-ja/strings.xml
@@ -15,6 +15,8 @@
     <string name="action_scan">サーバーのスキャン</string>
     <string name="action_refresh">クライアント一覧の更新</string>
     <string name="action_hide_offline">オフラインのクライアントを非表示</string>
+    <string name="action_prevent_screen_off">画面がオフになるのを防ぐ</string>
+
 
     <string name="title_activity_client_settings">クライアント設定</string>
     <string name="client_name">名前</string>

--- a/Snapcast/src/main/res/values/strings.xml
+++ b/Snapcast/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="action_scan">Scan for server</string>
     <string name="action_refresh">Refresh client list</string>
     <string name="action_hide_offline">Hide offline clients</string>
+    <string name="action_prevent_screen_off">Prevent screen from turning off</string>
     <string name="action_bar_failed">Cannot set ActionBar!</string>
 
     <string name="title_activity_client_settings">Client settings</string>


### PR DESCRIPTION
Addresses [this issue](https://github.com/badaix/snapdroid/issues/78) and [this comment](https://github.com/badaix/snapdroid/issues/3#issuecomment-1531143656)
It seemed the wakelock was implemented to counter the stopping of music when sleep starts. I've made it an optional checkbox within the UI.
This enabled me to have music playing while letting the backdrop start on my Fire TV stick. 
My fire tv would trigger a sleep however after 20 minutes (No way that i could find to change that in the UI). I fixed that by sending a `adb shell settings put secure sleep_timeout 0 ` command.

If desired I can also make a small note about this in the readme as documentation.

![image](https://github.com/user-attachments/assets/341c5e7b-bb03-464d-8bb0-9da26d98411a)

Tested on Fire TV 4k MAX with android 9.0
